### PR TITLE
Fix schema compilation errors

### DIFF
--- a/Appliance.xsd
+++ b/Appliance.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.iepmodel.net"
-	xmlns="http://www.iepmodel.net">
+	xmlns="http://www.iepmodel.net" elementFormDefault="qualified">
 	<xs:include schemaLocation="CommonSystemProperties.xsd"/>
 	<xs:element name="appliance" type="appliance"/>
 	<xs:complexType name="appliance">

--- a/Common.xsd
+++ b/Common.xsd
@@ -1682,7 +1682,7 @@ Use the Name attribute to capture optional name for the payment. For example, if
         <xs:annotation>
             <xs:documentation>NEMA provides ratings on equipment enclosures that describe its protection from weather/elements.
 
-Included in Common.xsd because EquipmentDefinitionType element uses it, else would be in CommonElectrical.xsd.</xs:documentation>
+Included in Common.xsd because equipmentDefinition element uses it, else would be in CommonElectrical.xsd.</xs:documentation>
         </xs:annotation>
         <xs:restriction base="xs:string">
             <xs:enumeration value="3"/>

--- a/CommonElectrical.xsd
+++ b/CommonElectrical.xsd
@@ -7,7 +7,7 @@
     Description: Schema includes elements for defining an electrical system on a site.  Includes elements that describe the distribution of circuits, such as electric panels, wiring, wireways (conduit), over-current protection devices (OCPD), and disconnects.
 **************************************************************************** -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.iepmodel.net"
-    targetNamespace="http://www.iepmodel.net" version="1.0">
+    targetNamespace="http://www.iepmodel.net" version="1.0" elementFormDefault="qualified">
     <xs:include schemaLocation="Common.xsd"/>
     <xs:simpleType name="wireTypeEnum">
         <xs:annotation>

--- a/CommonSystemProperties.xsd
+++ b/CommonSystemProperties.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.iepmodel.net"
-	xmlns="http://www.iepmodel.net">
+	xmlns="http://www.iepmodel.net" elementFormDefault="qualified">
 	<xs:annotation>
 		<xs:documentation>
 

--- a/DistributionSystem.xsd
+++ b/DistributionSystem.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.iepmodel.net"
-	xmlns="http://www.iepmodel.net">
+	xmlns="http://www.iepmodel.net" elementFormDefault="qualified">
 	<xs:include schemaLocation="Common.xsd"/>
 	<xs:include schemaLocation="CommonSystemProperties.xsd"/>
 	<xs:include schemaLocation="Building.xsd"/>
@@ -84,7 +84,7 @@ Heat Transfer Fluid</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element maxOccurs="unbounded" minOccurs="0" name="DistributionEquipmentDefinition"
-				type="EquipmentDefinitionType"/>
+				type="equipmentDefinition"/>
 			<xs:element name="PrimeMover" type="PrimeMoverSystemType" minOccurs="0"
 				maxOccurs="unbounded">
 				<xs:annotation>
@@ -115,14 +115,14 @@ Heat Transfer Fluid</xs:documentation>
 					<xs:documentation>Place for user to include additional notes/description of the system.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="DesignFlow" type="FlowType" minOccurs="0" maxOccurs="1">
+			<xs:element name="DesignFlow" type="flow" minOccurs="0" maxOccurs="1">
 				<xs:annotation>
 					<xs:documentation>The volumetric flow that the pump/fan was designed to provide. This correspondes to the Design Pressure.  
 
 Typically, the design pressure and design flow represent the maximum efficiency point on the manufacturer fan/pump curve. Typically, this is not the maximum flow that the device can provide.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="DesignPressure" type="PressureType" minOccurs="0" maxOccurs="1">
+			<xs:element name="DesignPressure" type="pressure" minOccurs="0" maxOccurs="1">
 				<xs:annotation>
 					<xs:documentation>The pressure across the pump/fan (P_outlet - P_inlet) that it was designed to provide. This corresponds to the the Design Flow.  
 
@@ -156,13 +156,13 @@ Inlet Guide Vane
 Outlet Damper</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="SystemProperties" type="CommonSystemPropertiesType" minOccurs="0"
+			<xs:element name="SystemProperties" type="commonSystemProperties" minOccurs="0"
 				maxOccurs="1">
 				<xs:annotation>
 					<xs:documentation>Characteristics of the system are captured here.  Note that this reflects the system (pump/fan, motor, VFD, etc.).  Properties of the individual components may be captured in equipment attributes.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="PrimeMoverEquipment" type="EquipmentInstanceType" minOccurs="0"
+			<xs:element name="PrimeMoverEquipment" type="equipmentInstance" minOccurs="0"
 				maxOccurs="unbounded">
 				<xs:annotation>
 					<xs:documentation>Details of the hardware are captured here.</xs:documentation>
@@ -197,20 +197,20 @@ If a complex system of segments is to be defined, it would be useful to describe
 Other quantities or features may also be described here, such as the loss coefficient (i.e. pressure drop due to fluid friction).</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="SegmentEquipment" type="EquipmentInstanceType" minOccurs="0"
+			<xs:element name="SegmentEquipment" type="equipmentInstance" minOccurs="0"
 				maxOccurs="unbounded">
 				<xs:annotation>
 					<xs:documentation>Characteristics of the segment (pipe/duct/etc.) hardware are captured here.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element maxOccurs="unbounded" minOccurs="0" name="Insulation" type="InsulationType"/>
-			<xs:element minOccurs="0" name="Leakage" type="LeakageType"/>
-			<xs:element name="PressureRated" type="PressureType" minOccurs="0" maxOccurs="1">
+			<xs:element maxOccurs="unbounded" minOccurs="0" name="Insulation" type="insulation"/>
+			<xs:element minOccurs="0" name="Leakage" type="flow"/>
+			<xs:element name="PressureRated" type="pressure" minOccurs="0" maxOccurs="1">
 				<xs:annotation>
 					<xs:documentation>The maximum or design pressure for which the pipe/duct segment is rated.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="FlowRated" type="FlowType" minOccurs="0" maxOccurs="1">
+			<xs:element name="FlowRated" type="flow" minOccurs="0" maxOccurs="1">
 				<xs:annotation>
 					<xs:documentation>The maximum or design flow rate for which the pipe/duct segment is rated.</xs:documentation>
 				</xs:annotation>

--- a/EnergyConsumption.xsd
+++ b/EnergyConsumption.xsd
@@ -6,7 +6,7 @@
 	1.x Michael Palmquist, SolarNexus Inc, with contributors: Devan Johnson, kW Engineering; Paul Cobb, SaveEnergy123
 **************************************************************************** -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.iepmodel.net"
-	xmlns="http://www.iepmodel.net">
+	xmlns="http://www.iepmodel.net" elementFormDefault="qualified">
 	<xs:annotation>
 		<xs:documentation>&lt;xs:include schemaLocation="\CommonQuantities.xsd"/&gt;
 

--- a/HVACSystem.xsd
+++ b/HVACSystem.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.iepmodel.net"
-	xmlns="http://www.iepmodel.net">
+	xmlns="http://www.iepmodel.net" elementFormDefault="qualified">
 	<xs:annotation>
 		<xs:documentation>This schema defines the parameters associated with an HVAC system.  
 
@@ -71,7 +71,7 @@ Note that parameters associated with the transport and movement of air and water
 				</xs:annotation>
 			</xs:element>
 			<xs:element maxOccurs="unbounded" minOccurs="0" name="HVACEquipmentDefinition"
-				type="EquipmentDefinitionType"/>
+				type="equipmentDefinition"/>
 			<xs:element minOccurs="0" name="DeliverySystem" type="DeliverySystemType">
 				<xs:annotation>
 					<xs:documentation>This describes the details of the way in which the HVAC system delivers conditioning to the space it conditions. This allows the user to define ducting or piping etc. This includes an optional reference to a distribution system.</xs:documentation>
@@ -109,7 +109,7 @@ Hydronic Coils
 Refrigerant (Direct Expansion, DX) Coils</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="SystemProperties" type="CommonSystemPropertiesType" minOccurs="0"/>
+			<xs:element name="SystemProperties" type="commonSystemProperties" minOccurs="0"/>
 			<xs:element maxOccurs="1" minOccurs="0" name="RefDistributionSystemCoolSource"
 				type="xs:IDREF">
 				<xs:annotation>
@@ -121,7 +121,7 @@ Examples:
 				</xs:annotation>
 			</xs:element>
 			<xs:element maxOccurs="unbounded" minOccurs="0" name="CoolingInstance" nillable="false"
-				type="EquipmentInstanceType"/>
+				type="equipmentInstance"/>
 		</xs:sequence>
 	</xs:complexType>
 	<xs:complexType name="HeatingSystemType">
@@ -150,7 +150,7 @@ Refrigeration – Water-Source
 Hydronic Coils</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="SystemProperties" type="CommonSystemPropertiesType" minOccurs="0"/>
+			<xs:element name="SystemProperties" type="commonSystemProperties" minOccurs="0"/>
 			<xs:element maxOccurs="1" minOccurs="0" name="RefDistributionSystemHeatSource"
 				type="xs:IDREF">
 				<xs:annotation>
@@ -162,7 +162,7 @@ Examples:
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="HeatingEquipment" maxOccurs="unbounded" minOccurs="0" nillable="false"
-				type="EquipmentInstanceType"/>
+				type="equipmentInstance"/>
 		</xs:sequence>
 	</xs:complexType>
 	<xs:complexType name="DeliverySystemType">

--- a/LightingSystem.xsd
+++ b/LightingSystem.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.iepmodel.net"
-	xmlns="http://www.iepmodel.net">
+	xmlns="http://www.iepmodel.net" elementFormDefault="qualified">
 	<xs:annotation>
 		<xs:documentation>&lt;xs:include schemaLocation="\CommonQuantities.xsd"/&gt;
 &lt;xs:include schemaLocation="\Equipment.xsd"/&gt;
@@ -53,7 +53,7 @@ This object may represent a collection of different types of lighting or it may 
 			<xs:documentation>This object defines a single type of light fixture. A light fixture consists of a combination of a lamps and ballasts (optional) as well as the container and mounting accessories.</xs:documentation>
 		</xs:annotation>
 		<xs:complexContent>
-			<xs:extension base="EquipmentDefinitionType">
+			<xs:extension base="equipmentDefinition">
 				<xs:sequence minOccurs="1" maxOccurs="1">
 					<xs:element minOccurs="0" name="FixtureEfficiency">
 						<xs:annotation>
@@ -143,7 +143,7 @@ In the future, this element may contain the actual IES file converted to a suita
 					<xs:documentation>This is a reference to a defined/instanced lighting zone.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="SystemProperties" type="CommonSystemPropertiesType"/>
+			<xs:element minOccurs="0" name="SystemProperties" type="commonSystemProperties"/>
 			<xs:element maxOccurs="unbounded" minOccurs="0" name="LightingFixture"
 				type="LightingFixtureGroupType">
 				<xs:annotation>
@@ -168,7 +168,7 @@ In the future, this element may contain the actual IES file converted to a suita
 			<xs:documentation>This is a collection of common lamp attributes. Note that the lamp type is known from the LightingTypeEnum which is used in the LightingSystem element Type.</xs:documentation>
 		</xs:annotation>
 		<xs:complexContent>
-			<xs:extension base="EquipmentDefinitionType">
+			<xs:extension base="equipmentDefinition">
 				<xs:sequence minOccurs="1" maxOccurs="1">
 					<xs:element name="CRI" type="xs:float" minOccurs="0" maxOccurs="1">
 						<xs:annotation>
@@ -244,7 +244,7 @@ In the future, this element may contain the actual IES file converted to a suita
 			<xs:documentation>A set of typical attributes associated with ballasts.</xs:documentation>
 		</xs:annotation>
 		<xs:complexContent>
-			<xs:extension base="EquipmentDefinitionType">
+			<xs:extension base="equipmentDefinition">
 				<xs:sequence minOccurs="1">
 					<xs:element name="BallastTechnology" type="xs:string" minOccurs="0"
 						maxOccurs="1">
@@ -371,7 +371,7 @@ The IESNA publishes a category set that describes the use case for lighting in a
 			<xs:documentation>This object defines a type of light fixture and the quantity of them.</xs:documentation>
 		</xs:annotation>
 		<xs:complexContent>
-			<xs:extension base="EquipmentInstanceType">
+			<xs:extension base="equipmentInstance">
 				<xs:sequence>
 					<xs:element name="Description" type="xs:string" minOccurs="0" maxOccurs="1">
 						<xs:annotation>

--- a/Participant.xsd
+++ b/Participant.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.iepmodel.net"
-	xmlns="http://www.iepmodel.net">
+	xmlns="http://www.iepmodel.net" elementFormDefault="qualified">
 	<xs:annotation>
 		<xs:documentation>Schema defines project participants. It is intended to cover all types of participants, including consumers, service providers, etc.
 		</xs:documentation>
@@ -39,7 +39,7 @@ mailing addresses are closely associated with the role of the participant, not t
 					</xs:sequence>
 				</xs:complexType>
 			</xs:element>
-			<xs:element minOccurs="0" name="adresses">
+			<xs:element minOccurs="0" name="addresses">
 				<xs:complexType>
 					<xs:sequence>
 						<xs:element name="address" type="address" minOccurs="1"

--- a/SolarThermalSystem.xsd
+++ b/SolarThermalSystem.xsd
@@ -205,7 +205,7 @@
                     <xs:documentation>Describes the installation style used for the array. The installation style categorizes the type of racking and mounting equipment used.</xs:documentation>
                 </xs:annotation>
             </xs:element>
-            <xs:element minOccurs="0" name="ArrayLocation" type="ArrayLocationType">
+            <xs:element minOccurs="0" name="ArrayLocation" type="xs:string">
                 <xs:annotation>
                     <xs:documentation>Describes where on the site that the array is located. It is a choice between referencing an existing RoofPlane element, an existing GroundArea element, or a text description.</xs:documentation>
                 </xs:annotation>
@@ -213,7 +213,7 @@
             <xs:element name="SolarExposure" minOccurs="0">
                 <xs:complexType>
                     <xs:choice>
-                        <xs:element name="ArraySpecificSolarExposure" type="SolarExposureType"/>
+                        <xs:element name="ArraySpecificSolarExposure" type="xs:string"/>
                         <xs:element name="InheritRoofPlaneSolarExposure" type="xs:IDREF"/>
                     </xs:choice>
                 </xs:complexType>

--- a/UtilityService.xsd
+++ b/UtilityService.xsd
@@ -6,7 +6,7 @@
 	v 1.x  Michael Palmquist, SolarNexus Inc
 **************************************************************************** -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.iepmodel.net"
-	xmlns="http://www.iepmodel.net">
+	xmlns="http://www.iepmodel.net" elementFormDefault="qualified">
 	<xs:annotation>
 		<xs:documentation>Defines a utility service for a site.</xs:documentation>
 	</xs:annotation>

--- a/WaterHeatingSystem.xsd
+++ b/WaterHeatingSystem.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.iepmodel.net"
-	xmlns="http://www.iepmodel.net">
+	xmlns="http://www.iepmodel.net" elementFormDefault="qualified">
 	<xs:include schemaLocation="Common.xsd"/>
 	<xs:include schemaLocation="CommonSystemProperties.xsd"/>
 	<xs:include schemaLocation="Schedule.xsd"/>
@@ -27,7 +27,7 @@ Attributes from Title24 WaterHeating</xs:documentation>
 					<xs:documentation>Place for user to include additional notes/description of the system.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="Fuel" type="EnergyClassEnumType"/>
+			<xs:element minOccurs="0" name="Fuel" type="energyClassEnum"/>
 			<xs:element name="HeatingMethod" type="xs:string" minOccurs="0" maxOccurs="1">
 				<xs:annotation>
 					<xs:documentation>Describe here what method is used to heat the water.
@@ -48,7 +48,7 @@ Note, that some of the examples above require additional objects to be defined. 
 - If solar, then additional details regarding the solar heating system are needed. This may simply be a reference to the distribution system that transfers heat from the solar panels to the water heating system. It may be an instance of Equipment Properties.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="TankVolume" type="VolumeType" minOccurs="0" maxOccurs="1">
+			<xs:element name="TankVolume" type="volume" minOccurs="0" maxOccurs="1">
 				<xs:annotation>
 					<xs:documentation>This element indicates the volume of water that the tank associated with the water-heating system can hold. If there is no tank, then this should have the value zero. Water heating systems wtih zero volume (no) tanks are commonly referred to as:
 - tankless
@@ -59,7 +59,7 @@ Note, that some of the examples above require additional objects to be defined. 
 Note that a hot water tank is not necessarily and does not have to be integrated with the water heating equipment. The water heater and the storage tank may be separate entities.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="TankInsulation" type="InsulationType"/>
+			<xs:element minOccurs="0" name="TankInsulation" type="insulation"/>
 			<xs:element maxOccurs="1" minOccurs="0" name="RefDistributionSystemHeatSource"
 				type="xs:IDREF">
 				<xs:annotation>
@@ -72,12 +72,12 @@ Another use case is when multiple water heaters are used in series. The first he
 Multiple hot water loops are often advantageous when the end uses are very far apart. The less distance that the hotter water has to travel, the less heat that will lost through the piping into the environment. It is then advantageous to boost the water temperature nearby the end use.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="SystemProperties" type="CommonSystemPropertiesType" minOccurs="0"
+			<xs:element name="SystemProperties" type="commonSystemProperties" minOccurs="0"
 				maxOccurs="1"/>
 			<xs:element maxOccurs="unbounded" minOccurs="0" name="WaterHeatingEquipmentDefinition"
-				type="EquipmentDefinitionType"/>
+				type="equipmentDefinition"/>
 			<xs:element maxOccurs="unbounded" minOccurs="0" name="WaterHeatingEquipment"
-				nillable="false" type="EquipmentInstanceType">
+				nillable="false" type="equipmentInstance">
 				<xs:annotation>
 					<xs:documentation>User may define any number of components of the system. 
 
@@ -123,7 +123,7 @@ This "capacity" is commonly used with domestic tankless (instantaneous) water he
 Systems in the U.S. are often rated in a maximum gpm (flow rate) with a 35 degree Fahrenheit temperature rise. Detailed manufacturer specifications often also list the temperature rise at various flow rates.</xs:documentation>
 		</xs:annotation>
 		<xs:sequence minOccurs="0" maxOccurs="1">
-			<xs:element name="RatedTemperatureRise" type="TemperatureType" minOccurs="1"
+			<xs:element name="RatedTemperatureRise" type="temperature" minOccurs="1"
 				maxOccurs="1">
 				<xs:annotation>
 					<xs:documentation>The change in temperature of the water between the inlet and outlet of the water heating system when it is operating at full load (maximum heat output or firing rate).
@@ -131,7 +131,7 @@ Systems in the U.S. are often rated in a maximum gpm (flow rate) with a 35 degre
 This Rated Temperature Rise corresponds to the Rated Flow Rate.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="RatedFlowRate" type="FlowType" minOccurs="1" maxOccurs="1">
+			<xs:element name="RatedFlowRate" type="flow" minOccurs="1" maxOccurs="1">
 				<xs:annotation>
 					<xs:documentation>The flow rate through the water heating system that corresponds to the Rated Temperature Rise when the system is operating at full load (maximum heat output or firing rate).</xs:documentation>
 				</xs:annotation>

--- a/Zone.xsd
+++ b/Zone.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.iepmodel.net"
-	xmlns="http://www.iepmodel.net">
+	xmlns="http://www.iepmodel.net" elementFormDefault="qualified">
 	<xs:annotation>
 		<xs:documentation>A Zone should point to systems that condition it.  (Systems point to a zone to indicate location - where the equipment resides).</xs:documentation>
 	</xs:annotation>


### PR DESCRIPTION
Errors reported before these changes:

```
$ xmllint --noout --schema Project.xsd solarnexus.xml
DistributionSystem.xsd:87: element element: Schemas parser error : element decl. 'DistributionEquipmentDefinition', attribute 'type': The QName value '{http://www.iepmodel.net}EquipmentDefinitionType' does not resolve to a(n) type definition.
DistributionSystem.xsd:118: element element: Schemas parser error : element decl. 'DesignFlow', attribute 'type': The QName value '{http://www.iepmodel.net}FlowType' does not resolve to a(n) type definition.
DistributionSystem.xsd:125: element element: Schemas parser error : element decl. 'DesignPressure', attribute 'type': The QName value '{http://www.iepmodel.net}PressureType' does not resolve to a(n) type definition.
DistributionSystem.xsd:160: element element: Schemas parser error : element decl. 'SystemProperties', attribute 'type': The QName value '{http://www.iepmodel.net}CommonSystemPropertiesType' does not resolve to a(n) type definition.
DistributionSystem.xsd:166: element element: Schemas parser error : element decl. 'PrimeMoverEquipment', attribute 'type': The QName value '{http://www.iepmodel.net}EquipmentInstanceType' does not resolve to a(n) type definition.
DistributionSystem.xsd:201: element element: Schemas parser error : element decl. 'SegmentEquipment', attribute 'type': The QName value '{http://www.iepmodel.net}EquipmentInstanceType' does not resolve to a(n) type definition.
DistributionSystem.xsd:206: element element: Schemas parser error : element decl. 'Insulation', attribute 'type': The QName value '{http://www.iepmodel.net}InsulationType' does not resolve to a(n) type definition.
DistributionSystem.xsd:207: element element: Schemas parser error : element decl. 'Leakage', attribute 'type': The QName value '{http://www.iepmodel.net}LeakageType' does not resolve to a(n) type definition.
DistributionSystem.xsd:208: element element: Schemas parser error : element decl. 'PressureRated', attribute 'type': The QName value '{http://www.iepmodel.net}PressureType' does not resolve to a(n) type definition.
DistributionSystem.xsd:213: element element: Schemas parser error : element decl. 'FlowRated', attribute 'type': The QName value '{http://www.iepmodel.net}FlowType' does not resolve to a(n) type definition.
HVACSystem.xsd:74: element element: Schemas parser error : element decl. 'HVACEquipmentDefinition', attribute 'type': The QName value '{http://www.iepmodel.net}EquipmentDefinitionType' does not resolve to a(n) type definition.
HVACSystem.xsd:112: element element: Schemas parser error : element decl. 'SystemProperties', attribute 'type': The QName value '{http://www.iepmodel.net}CommonSystemPropertiesType' does not resolve to a(n) type definition.
HVACSystem.xsd:124: element element: Schemas parser error : element decl. 'CoolingInstance', attribute 'type': The QName value '{http://www.iepmodel.net}EquipmentInstanceType' does not resolve to a(n) type definition.
HVACSystem.xsd:153: element element: Schemas parser error : element decl. 'SystemProperties', attribute 'type': The QName value '{http://www.iepmodel.net}CommonSystemPropertiesType' does not resolve to a(n) type definition.
HVACSystem.xsd:165: element element: Schemas parser error : element decl. 'HeatingEquipment', attribute 'type': The QName value '{http://www.iepmodel.net}EquipmentInstanceType' does not resolve to a(n) type definition.
LightingSystem.xsd:51: element complexType: Schemas parser error : complex type 'LightingFixtureDefintionType', attribute 'base': The QName value '{http://www.iepmodel.net}EquipmentDefinitionType' does not resolve to a(n) simple type definition.
LightingSystem.xsd:146: element element: Schemas parser error : element decl. 'SystemProperties', attribute 'type': The QName value '{http://www.iepmodel.net}CommonSystemPropertiesType' does not resolve to a(n) type definition.
LightingSystem.xsd:166: element complexType: Schemas parser error : complex type 'LampPropertiesType', attribute 'base': The QName value '{http://www.iepmodel.net}EquipmentDefinitionType' does not resolve to a(n) simple type definition.
LightingSystem.xsd:242: element complexType: Schemas parser error : complex type 'BallastPropertiesType', attribute 'base': The QName value '{http://www.iepmodel.net}EquipmentDefinitionType' does not resolve to a(n) simple type definition.
LightingSystem.xsd:369: element complexType: Schemas parser error : complex type 'LightingFixtureGroupType', attribute 'base': The QName value '{http://www.iepmodel.net}EquipmentInstanceType' does not resolve to a(n) simple type definition.
SolarThermalSystem.xsd:208: element element: Schemas parser error : element decl. 'ArrayLocation', attribute 'type': The QName value '{http://www.iepmodel.net}ArrayLocationType' does not resolve to a(n) type definition.
SolarThermalSystem.xsd:216: element element: Schemas parser error : element decl. 'ArraySpecificSolarExposure', attribute 'type': The QName value '{http://www.iepmodel.net}SolarExposureType' does not resolve to a(n) type definition.
WaterHeatingSystem.xsd:30: element element: Schemas parser error : element decl. 'Fuel', attribute 'type': The QName value '{http://www.iepmodel.net}EnergyClassEnumType' does not resolve to a(n) type definition.
WaterHeatingSystem.xsd:51: element element: Schemas parser error : element decl. 'TankVolume', attribute 'type': The QName value '{http://www.iepmodel.net}VolumeType' does not resolve to a(n) type definition.
WaterHeatingSystem.xsd:62: element element: Schemas parser error : element decl. 'TankInsulation', attribute 'type': The QName value '{http://www.iepmodel.net}InsulationType' does not resolve to a(n) type definition.
WaterHeatingSystem.xsd:76: element element: Schemas parser error : element decl. 'SystemProperties', attribute 'type': The QName value '{http://www.iepmodel.net}CommonSystemPropertiesType' does not resolve to a(n) type definition.
WaterHeatingSystem.xsd:78: element element: Schemas parser error : element decl. 'WaterHeatingEquipmentDefinition', attribute 'type': The QName value '{http://www.iepmodel.net}EquipmentDefinitionType' does not resolve to a(n) type definition.
WaterHeatingSystem.xsd:80: element element: Schemas parser error : element decl. 'WaterHeatingEquipment', attribute 'type': The QName value '{http://www.iepmodel.net}EquipmentInstanceType' does not resolve to a(n) type definition.
WaterHeatingSystem.xsd:127: element element: Schemas parser error : element decl. 'RatedTemperatureRise', attribute 'type': The QName value '{http://www.iepmodel.net}TemperatureType' does not resolve to a(n) type definition.
WaterHeatingSystem.xsd:134: element element: Schemas parser error : element decl. 'RatedFlowRate', attribute 'type': The QName value '{http://www.iepmodel.net}FlowType' does not resolve to a(n) type definition.
WXS schema Project.xsd failed to compile
```

I took a best guess on the `type` attributes. There were a few that I couldn't find, so I used `xs:string` as a placeholder.

Once the schema compiled, I got validation errors that were fixed by adding `elementFormDefault="qualified"`.

```
(es)$ xmllint --noout --schema Project.xsd solarnexus.xml
solarnexus.xml:28: element participantType: Schemas validity error : Element '{http://www.iepmodel.net}participantType': This element is not expected. Expected is one of ( participantType, taxStatus, organization, contacts ).
solarnexus.xml fails to validate
```
