### PR TITLE
Schema changes to support SDT projects

### DIFF
--- a/Common.xsd
+++ b/Common.xsd
@@ -111,6 +111,11 @@ This is also used for PowerClerk/CSI program</xs:documentation>
 Note that if there are more than one street address, the model forces these to be separate Sites/Projects. If a Building on the project site has more than one street address, only one is required to identify the location.</xs:documentation>
                 </xs:annotation>
             </xs:element>
+            <xs:element name="siteMapCoordinateSystemOrigin" type="geoLocation" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>All site geometry coordinates are in meters relative to this origin. The coordinate of this origin is (0;0).</xs:documentation>
+                </xs:annotation>
+            </xs:element>
             <xs:element name="siteDefinitionMethod" minOccurs="0">
                 <xs:annotation>
                     <xs:documentation>Describes how the site was originally defined. Was it a trace over aerial imagery, or was it an import a 3D model?</xs:documentation>
@@ -637,36 +642,47 @@ ISSUES / TO DO:
         <xs:sequence>
             <xs:element name="latitude" type="xs:double"/>
             <xs:element name="longitude" type="xs:double"/>
-            <xs:element name="altitude" type="xs:double"/>
-            <xs:element name="altitudeReference" default="Ground">
-                <xs:annotation>
-                    <xs:documentation>Reference for 'altitude' element.</xs:documentation>
-                </xs:annotation>
-                <xs:simpleType>
-                    <xs:restriction base="xs:string">
-                        <xs:enumeration value="Ground">
-                            <xs:annotation>
-                                <xs:documentation>The altitude is measured from the ground.</xs:documentation>
-                            </xs:annotation>
-                        </xs:enumeration>
-                        <xs:enumeration value="Ellipsoid">
-                            <xs:annotation>
-                                <xs:documentation>The altitude is measured from the ellipsoid.</xs:documentation>
-                            </xs:annotation>
-                        </xs:enumeration>
-                        <xs:enumeration value="SeaLevel">
-                            <xs:annotation>
-                                <xs:documentation>The altitude is measured from sea level.</xs:documentation>
-                            </xs:annotation>
-                        </xs:enumeration>
-                    </xs:restriction>
-                </xs:simpleType>
-            </xs:element>
         </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="geoLocationWithAltitude">
+        <xs:annotation>
+            <xs:documentation>Geographic location that also considers altitude.</xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="geoLocation">
+                <xs:sequence>
+                    <xs:element name="altitude" type="xs:double"/>
+                    <xs:element name="altitudeReference" default="Ground">
+                        <xs:annotation>
+                            <xs:documentation>Reference for 'altitude' element.</xs:documentation>
+                        </xs:annotation>
+                        <xs:simpleType>
+                            <xs:restriction base="xs:string">
+                                <xs:enumeration value="Ground">
+                                    <xs:annotation>
+                                        <xs:documentation>The altitude is measured from the ground.</xs:documentation>
+                                    </xs:annotation>
+                                </xs:enumeration>
+                                <xs:enumeration value="Ellipsoid">
+                                    <xs:annotation>
+                                        <xs:documentation>The altitude is measured from the ellipsoid.</xs:documentation>
+                                    </xs:annotation>
+                                </xs:enumeration>
+                                <xs:enumeration value="SeaLevel">
+                                    <xs:annotation>
+                                        <xs:documentation>The altitude is measured from sea level.</xs:documentation>
+                                    </xs:annotation>
+                                </xs:enumeration>
+                            </xs:restriction>
+                        </xs:simpleType>
+                    </xs:element>
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
     </xs:complexType>
     <xs:complexType name="point2d">
         <xs:annotation>
-            <xs:documentation>A ccordinate location in 2 dimensional space.</xs:documentation>
+            <xs:documentation>A coordinate location in 2 dimensional space.</xs:documentation>
         </xs:annotation>
         <xs:sequence>
             <xs:element name="x" type="xs:double"/>
@@ -680,7 +696,7 @@ ISSUES / TO DO:
     </xs:complexType>
     <xs:complexType name="point3d">
         <xs:annotation>
-            <xs:documentation>A ccordinate location in 3 dimensional space.</xs:documentation>
+            <xs:documentation>A coordinate location in 3 dimensional space.</xs:documentation>
         </xs:annotation>
         <xs:sequence>
             <xs:element name="x" type="xs:double"/>

--- a/PvSystem.xsd
+++ b/PvSystem.xsd
@@ -4,7 +4,7 @@
     Author(s):
     v 2.0 Michael Palmquist (SolarNexus Inc). Input From: Derek Mitchell (Verdiseno, SolarDesignTool.com)
     v 1.x Michael Palmquist (SolarNexus Inc). Input From: Mark Galli (Solmetric)
-    Description: This schema defines complete PV systems. It is modular. It can define any system architiecture at
+    Description: This schema defines complete PV systems. It is modular. It can define any system architecture at
     various levels of detail.
 **************************************************************************** -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.iepmodel.net"
@@ -28,7 +28,7 @@
                         <xs:element minOccurs="1" name="applicationReferenceId" type="applicationId"
                             maxOccurs="unbounded">
                             <xs:annotation>
-                                <xs:documentation>ID of the object represented by this XML rewithin a  corresponding software application. Used by the software to identify its corresponding record within the application's database. AKA a primary key. Important if the data is passed from one application back to an originating application, for example. </xs:documentation>
+                                <xs:documentation>ID of the object represented by this XML within a  corresponding software application. Used by the software to identify its corresponding record within the application's database. AKA a primary key. Important if the data is passed from one application back to an originating application, for example. </xs:documentation>
                             </xs:annotation>
                         </xs:element>
                     </xs:sequence>
@@ -203,9 +203,9 @@ NOTE: An AC Module is assumed to be either:
                 </xs:annotation>
             </xs:element>
             <xs:element minOccurs="0" name="acPointOfConnection" type="acPointOfConnection"/>
-            <xs:element name="sceneOriginGeoTag" type="geoLocation" minOccurs="0" maxOccurs="1">
+            <xs:element name="sceneOriginGeoTag" type="geoLocationWithAltitude" minOccurs="0" maxOccurs="1">
                 <xs:annotation>
-                    <xs:documentation>Coordinate system geo reference origin for the system.  All child components that specify 3D coordinates are in units meters relative to this location.  The 3D coordinate of this origin is (0,0,0).</xs:documentation>
+                    <xs:documentation>Coordinate system geo reference origin for the system. All child components that specify 3D coordinates are in units meters relative to this location. The 3D coordinate of this origin is (0,0,0).</xs:documentation>
                 </xs:annotation>
             </xs:element>
         </xs:sequence>


### PR DESCRIPTION
Separate changes in separate commits:
### 1st commit
Added `//site/siteMapCoordinateSystemOrigin` element to specify origin point of all site geometry

Notes:
1. The origin point has just the lat/long, no altitude.

### 2nd commit
Removed `//site/weatherData` in favor of a new `//site/designParameters` element. The new element holds info about codes that apply, temperature datasets and structural design parameters. Example:
```xml
<iep:designParameters>
  <iep:codes>
    <iep:code type="FIRE" codeBody="CALIFORNIA" edition="2016"/>
    <iep:code type="ELECTRIC" codeBody="NATIONAL_FIRE_PROTECTION_ASSOCIATION" edition="2016"/>
  </iep:codes>
  <iep:temperature>
    <iep:temperatureDataset type="HIGH" source="ASHRAE" dateRecorded="2017-07-30" description="Optional comment or description of the dataset">
      <iep:temperatureDataPoint type="HIGHEST_MONTH_TWO_PERCENT_DRY_BULB">32</iep:temperatureDataPoint>
      <iep:temperatureDataPoint type="MAXIMUM_MEAN_EXTREME_DRY_BULB">38</iep:temperatureDataPoint>
    </iep:temperatureDataset>
    <iep:temperatureDataset type="HIGH" source="HISTORIC" dateRecorded="2015-01-22">
      <iep:temperatureDataPoint type="HIGHEST_MONTHLY_AVERAGE">29</iep:temperatureDataPoint>
    </iep:temperatureDataset>
    <iep:temperatureDataset type="LOW" source="HISTORIC" dateRecorded="2015-01-22">
      <iep:temperatureDataPoint type="RECORD_LOW">-8</iep:temperatureDataPoint>
    </iep:temperatureDataset>
  </iep:temperature>
  <iep:structuralDesign>
    <iep:asceEdition>ASCE_7_10</iep:asceEdition>
    <iep:highestRiskCategory>II</iep:highestRiskCategory>
    <iep:windExposureCategory>B</iep:windExposureCategory>
    <iep:topographicalCondition>STANDARD</iep:topographicalCondition>
    <iep:designWindSpeed unit="MILES_PER_HOUR">110</iep:designWindSpeed>
    <iep:specialWindRegion>false</iep:specialWindRegion>
    <iep:groundSnowLoad>0</iep:groundSnowLoad>
  </iep:structuralDesign>
</iep:designParameters>
```

Notes:
1. `//site/weather` element is removed. Its elements:
    - `stationCategory` - removed
    - `stationId` - removed
    - `weatherDataset` - removed
    - `highestMonthlyAverageHighTemperature` - replaced by `designParameters/temperature`
    - `recordLowTemperture` - replaced by `designParameters/temperature`
    - `designWindSpeed` - replaced by `designParameters/structuralDesign`
1. The whole `//designParameters` element is new - we will probably need a few iterations to polish it. Please think through if it would support your use-cases.
1. Enumerations are used extensively, but I'm not sure if I have specified all the required values.
1. `weatherData` type is removed from `CommonSolar.xsd`, because it was not used on any element.