### PR TITLE
Add //site/siteMapCoordinateSystemOrigin element

### DIFF
--- a/Common.xsd
+++ b/Common.xsd
@@ -111,6 +111,11 @@ This is also used for PowerClerk/CSI program</xs:documentation>
 Note that if there are more than one street address, the model forces these to be separate Sites/Projects. If a Building on the project site has more than one street address, only one is required to identify the location.</xs:documentation>
                 </xs:annotation>
             </xs:element>
+            <xs:element name="siteMapCoordinateSystemOrigin" type="geoLocation" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>All site geometry coordinates are in meters relative to this origin. The coordinate of this origin is (0;0).</xs:documentation>
+                </xs:annotation>
+            </xs:element>
             <xs:element name="siteDefinitionMethod" minOccurs="0">
                 <xs:annotation>
                     <xs:documentation>Describes how the site was originally defined. Was it a trace over aerial imagery, or was it an import a 3D model?</xs:documentation>
@@ -637,36 +642,47 @@ ISSUES / TO DO:
         <xs:sequence>
             <xs:element name="latitude" type="xs:double"/>
             <xs:element name="longitude" type="xs:double"/>
-            <xs:element name="altitude" type="xs:double"/>
-            <xs:element name="altitudeReference" default="Ground">
-                <xs:annotation>
-                    <xs:documentation>Reference for 'altitude' element.</xs:documentation>
-                </xs:annotation>
-                <xs:simpleType>
-                    <xs:restriction base="xs:string">
-                        <xs:enumeration value="Ground">
-                            <xs:annotation>
-                                <xs:documentation>The altitude is measured from the ground.</xs:documentation>
-                            </xs:annotation>
-                        </xs:enumeration>
-                        <xs:enumeration value="Ellipsoid">
-                            <xs:annotation>
-                                <xs:documentation>The altitude is measured from the ellipsoid.</xs:documentation>
-                            </xs:annotation>
-                        </xs:enumeration>
-                        <xs:enumeration value="SeaLevel">
-                            <xs:annotation>
-                                <xs:documentation>The altitude is measured from sea level.</xs:documentation>
-                            </xs:annotation>
-                        </xs:enumeration>
-                    </xs:restriction>
-                </xs:simpleType>
-            </xs:element>
         </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="geoLocationWithAltitude">
+        <xs:annotation>
+            <xs:documentation>Geographic location that also considers altitude.</xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="geoLocation">
+                <xs:sequence>
+                    <xs:element name="altitude" type="xs:double"/>
+                    <xs:element name="altitudeReference" default="Ground">
+                        <xs:annotation>
+                            <xs:documentation>Reference for 'altitude' element.</xs:documentation>
+                        </xs:annotation>
+                        <xs:simpleType>
+                            <xs:restriction base="xs:string">
+                                <xs:enumeration value="Ground">
+                                    <xs:annotation>
+                                        <xs:documentation>The altitude is measured from the ground.</xs:documentation>
+                                    </xs:annotation>
+                                </xs:enumeration>
+                                <xs:enumeration value="Ellipsoid">
+                                    <xs:annotation>
+                                        <xs:documentation>The altitude is measured from the ellipsoid.</xs:documentation>
+                                    </xs:annotation>
+                                </xs:enumeration>
+                                <xs:enumeration value="SeaLevel">
+                                    <xs:annotation>
+                                        <xs:documentation>The altitude is measured from sea level.</xs:documentation>
+                                    </xs:annotation>
+                                </xs:enumeration>
+                            </xs:restriction>
+                        </xs:simpleType>
+                    </xs:element>
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
     </xs:complexType>
     <xs:complexType name="point2d">
         <xs:annotation>
-            <xs:documentation>A ccordinate location in 2 dimensional space.</xs:documentation>
+            <xs:documentation>A coordinate location in 2 dimensional space.</xs:documentation>
         </xs:annotation>
         <xs:sequence>
             <xs:element name="x" type="xs:double"/>
@@ -680,7 +696,7 @@ ISSUES / TO DO:
     </xs:complexType>
     <xs:complexType name="point3d">
         <xs:annotation>
-            <xs:documentation>A ccordinate location in 3 dimensional space.</xs:documentation>
+            <xs:documentation>A coordinate location in 3 dimensional space.</xs:documentation>
         </xs:annotation>
         <xs:sequence>
             <xs:element name="x" type="xs:double"/>

--- a/PvSystem.xsd
+++ b/PvSystem.xsd
@@ -4,7 +4,7 @@
     Author(s):
     v 2.0 Michael Palmquist (SolarNexus Inc). Input From: Derek Mitchell (Verdiseno, SolarDesignTool.com)
     v 1.x Michael Palmquist (SolarNexus Inc). Input From: Mark Galli (Solmetric)
-    Description: This schema defines complete PV systems. It is modular. It can define any system architiecture at
+    Description: This schema defines complete PV systems. It is modular. It can define any system architecture at
     various levels of detail.
 **************************************************************************** -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.iepmodel.net"
@@ -28,7 +28,7 @@
                         <xs:element minOccurs="1" name="applicationReferenceId" type="applicationId"
                             maxOccurs="unbounded">
                             <xs:annotation>
-                                <xs:documentation>ID of the object represented by this XML rewithin a  corresponding software application. Used by the software to identify its corresponding record within the application's database. AKA a primary key. Important if the data is passed from one application back to an originating application, for example. </xs:documentation>
+                                <xs:documentation>ID of the object represented by this XML within a  corresponding software application. Used by the software to identify its corresponding record within the application's database. AKA a primary key. Important if the data is passed from one application back to an originating application, for example. </xs:documentation>
                             </xs:annotation>
                         </xs:element>
                     </xs:sequence>
@@ -203,9 +203,9 @@ NOTE: An AC Module is assumed to be either:
                 </xs:annotation>
             </xs:element>
             <xs:element minOccurs="0" name="acPointOfConnection" type="acPointOfConnection"/>
-            <xs:element name="sceneOriginGeoTag" type="geoLocation" minOccurs="0" maxOccurs="1">
+            <xs:element name="sceneOriginGeoTag" type="geoLocationWithAltitude" minOccurs="0" maxOccurs="1">
                 <xs:annotation>
-                    <xs:documentation>Coordinate system geo reference origin for the system.  All child components that specify 3D coordinates are in units meters relative to this location.  The 3D coordinate of this origin is (0,0,0).</xs:documentation>
+                    <xs:documentation>Coordinate system geo reference origin for the system. All child components that specify 3D coordinates are in units meters relative to this location. The 3D coordinate of this origin is (0,0,0).</xs:documentation>
                 </xs:annotation>
             </xs:element>
         </xs:sequence>


### PR DESCRIPTION
I'll now be creating multiple smaller PRs to make it easier to:
1. Merge changes that we agree on faster
1. Isolate areas for discussion. Please do not close the PR if you want some changes made - just write a comment and I will update the pull request.

In this commit I added //site/siteMapCoordinateSystemOrigin element to specify origin point of all site geometry.

Notes:
-    The origin point has just the lat/long, no altitude.
