### PR TITLE
Separate mountingSystem definition from instance

### DIFF
--- a/CommonSolar.xsd
+++ b/CommonSolar.xsd
@@ -78,7 +78,15 @@
             <xs:enumeration value="FLOATING"/>
         </xs:restriction>
     </xs:simpleType>
-    <xs:complexType name="mountingSystem">
+    <xs:complexType name="mountingSystemDefinitions">
+        <xs:annotation>
+            <xs:documentation>A collection of mounting system definitions in the associated system.</xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="mountingSystemDefinition" type="mountingSystemDefinition" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="mountingSystemDefinition">
         <xs:annotation>
             <xs:documentation>Describes the physical mounting structure used to secure an array of solar panels (may be photovoltaic or thermal).</xs:documentation>
         </xs:annotation>
@@ -89,32 +97,40 @@
                     <xs:documentation>Include model numbers and descriptions of mounting system components.  Note, if there is more than one manufacturer's parts used, list the secondary mfr's name here with its component.</xs:documentation>
                 </xs:annotation>
             </xs:element>
-            <xs:element minOccurs="0" name="numberOfRowsPerRack" type="xs:int" default="1">
+            <xs:element minOccurs="0" name="anchorFastenerDiameter" type="xs:double">
                 <xs:annotation>
-                    <xs:documentation>Describes the quantity of module rows within a single rack structure. Ground mount tilted racks typically have multiple module rows.</xs:documentation>
+                    <xs:documentation>For expedited permitting, if cannot verify that proposed anchor fasteners suit racking manufacturer guidelines, then need to specify the diameter of lag screw, hanger bolt, or self-drilling screw used to fasten anchors.</xs:documentation>
                 </xs:annotation>
             </xs:element>
+            <xs:element minOccurs="0" name="roofPenetrationWeatherProofing" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation>Description of the method used to weatherproof roof penetrations (e.g. flashing, caulk) </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+        <xs:attribute name="id" type="xs:ID" use="required"/>
+    </xs:complexType>
+    <xs:complexType name="mountingSystem">
+        <xs:annotation>
+            <xs:documentation>Describes the instance of a physical mounting structure used to secure an array of solar panels (may be photovoltaic or thermal).</xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
             <xs:element minOccurs="0" name="anchorTotal" type="xs:integer">
                 <xs:annotation>
                     <xs:documentation>Total number of attachment points for the array. Anchors are also known as “stand-offs”, “feet”, “mounts” or “points of attachment.”</xs:documentation>
                 </xs:annotation>
             </xs:element>
+            <xs:element minOccurs="0" name="anchorsInAdjacentRowsStaggered" type="xs:boolean"/>
             <xs:element minOccurs="0" name="anchorMaxHorizontalSpacing" type="xs:double"
-                form="qualified">
+                        form="qualified">
                 <xs:annotation>
                     <xs:documentation>The maximum horizontal spacing allowed between attachment points. Horizontal anchor spacing is also known as “cross-slope” or “east-west” anchor spacing. See racking product manual for maximum spacing allowed based on maximum design wind speed, and permitting guidelines for maximum spacing allowed for structural load. </xs:documentation>
                 </xs:annotation>
             </xs:element>
-            <xs:element minOccurs="0" name="anchorsInAdjacentRowsStaggered" type="xs:boolean"/>
             <xs:element minOccurs="0" name="anchorFastenersMeetManufacturerGuidelines"
-                type="xs:boolean">
+                        type="xs:boolean">
                 <xs:annotation>
                     <xs:documentation>Do the proposed anchor fasteners meet the manufacturer’s guidelines, if provided? If yes, may be suitable enough to not require defining anchor fastener diameter and embedment.</xs:documentation>
-                </xs:annotation>
-            </xs:element>
-            <xs:element minOccurs="0" name="anchorFastenerDiameter" type="xs:double">
-                <xs:annotation>
-                    <xs:documentation>For expedited permitting, if cannot verify that proposed anchor fasteners suit racking manufacturer guidelines, then need to specify the diameter of lag screw, hanger bolt, or self-drilling screw used to fasten anchors.</xs:documentation>
                 </xs:annotation>
             </xs:element>
             <xs:element minOccurs="0" name="anchorFastenerEmbedmentDepth" type="xs:double">
@@ -127,6 +143,11 @@
                     <xs:documentation>Typically one screw per anchor.</xs:documentation>
                 </xs:annotation>
             </xs:element>
+            <xs:element minOccurs="0" name="numberOfRowsPerRack" type="xs:int" default="1">
+                <xs:annotation>
+                    <xs:documentation>Describes the quantity of module rows within a single rack structure. Ground mount tilted racks typically have multiple module rows.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
             <xs:element minOccurs="0" name="totalArrayWeight" type="xs:double">
                 <xs:annotation>
                     <xs:documentation>Total weight in pounds (lbs) of the array's panels and its mounting structure components.</xs:documentation>
@@ -137,12 +158,12 @@
                     <xs:documentation>The total surface area (in square feet) of all the panels in the array.</xs:documentation>
                 </xs:annotation>
             </xs:element>
-            <xs:element minOccurs="0" name="roofPenetrationWeatherProofing" type="xs:string">
-                <xs:annotation>
-                    <xs:documentation>Description of the method used to weatherproof roof penetrations (e.g. flashing, caulk) </xs:documentation>
-                </xs:annotation>
-            </xs:element>
         </xs:sequence>
+        <xs:attribute name="mountingSystemDefinitionIdRef" type="xs:IDREF" use="required">
+            <xs:annotation>
+                <xs:documentation>A reference to a mounting system definition.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
     </xs:complexType>
     <xs:complexType name="inverterDefinition">
         <xs:annotation>

--- a/CommonSolar.xsd
+++ b/CommonSolar.xsd
@@ -97,6 +97,20 @@
                     <xs:documentation>Include model numbers and descriptions of mounting system components.  Note, if there is more than one manufacturer's parts used, list the secondary mfr's name here with its component.</xs:documentation>
                 </xs:annotation>
             </xs:element>
+            <xs:element minOccurs="0" name="railManufacturer" type="xs:string"/>
+            <xs:element minOccurs="0" name="railProductFamily" type="xs:string"/>
+            <xs:element minOccurs="0" name="anchorManufacturer" type="xs:string"/>
+            <xs:element minOccurs="0" name="anchorModel" type="xs:string"/>
+            <xs:element minOccurs="0" name="minAnchorFastenersPerAnchor" type="xs:integer">
+                <xs:annotation>
+                    <xs:documentation>Minimum number of anchor fasteners per anchor. Usually one, but sometimes two.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element minOccurs="0" name="maxAnchorFastenersPerAnchor" type="xs:integer">
+                <xs:annotation>
+                    <xs:documentation>Maximum number of anchor fasteners per anchor. Usually one, but sometimes up to eight.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
             <xs:element minOccurs="0" name="anchorFastenerDiameter" type="xs:double">
                 <xs:annotation>
                     <xs:documentation>For expedited permitting, if cannot verify that proposed anchor fasteners suit racking manufacturer guidelines, then need to specify the diameter of lag screw, hanger bolt, or self-drilling screw used to fasten anchors.</xs:documentation>

--- a/PvSystem.xsd
+++ b/PvSystem.xsd
@@ -34,6 +34,7 @@
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
+            <xs:element minOccurs="0" name="mountingSystemDefinitions" type="mountingSystemDefinitions"/>
             <xs:element minOccurs="0" name="pvModuleDefinitions">
                 <xs:annotation>
                     <xs:documentation>A collection of the specifications of each PV module make/model used in the PV system.</xs:documentation>

--- a/SolarThermalSystem.xsd
+++ b/SolarThermalSystem.xsd
@@ -220,6 +220,7 @@
             </xs:element>
             <xs:element minOccurs="0" name="CollectorStandoff" type="xs:string"/>
             <xs:element minOccurs="0" name="CollectorOrientation" type="panelOrientationEnum"/>
+            <xs:element minOccurs="0" name="MountingSystemDefinition" type="mountingSystemDefinition"/>
             <xs:element minOccurs="0" name="MountingSystem" type="mountingSystem"/>
             <xs:element minOccurs="0" name="RoofFace" type="roofFace" maxOccurs="unbounded"/>
         </xs:sequence>


### PR DESCRIPTION
This PR separates `mountingSystem` into:
- `mountingSystemDefinition` (holding attributes common to this type of mounting system) and
- `mountingSystem` (holding attributes related to a specific instance).

This pattern is all over IEP model. The goal of this change is to make further changes/improvements to mounting system model easier.

**Element structure after proposed change:**

    - pvSystem
        - mountingSystemDefinitions
        - pvArrays
            - pvArray
                - mountingSystem
            - pvArray
                - mountingSystem

**Attributes on definition and instance**
Overall I did not add/remove any attributes, they are just moved to either definition or instance.
Let me know if I should move any of them to the other type.

   - mountingSystemDefinition
       - id (attribute - ID)
       - manufacturer (string)
       - componentsDescription (string)
       - numberOfRowsPerRack (int)
       - anchorMaxHorizontalSpacing (double)
       - anchorFastenersMeetManufacturerGuidelines (boolean)
       - anchorFastenerDiameter (double)
       - anchorFastenerEmbedmentDepth (double)
       - anchorFastenersPerAnchor (int)
       - roofPenetrationWeatherProofing (string)
   - mountingSystem
       - mountingSystemDefinitionIdRef (attribute - IDREF)
       - anchorsInAdjacentRowsStaggered (boolean)
       - totalArrayWeight (double)
       - totalPanelSurfaceArea (double)