### PR TITLE
Replaced //site/weather with a new //project/designParameters element

### DIFF
--- a/Common.xsd
+++ b/Common.xsd
@@ -167,7 +167,6 @@ Note that if there are more than one street address, the model forces these to b
                     <xs:documentation>Does the site have, or can get broadband internet? Dial-up only probably won't work.</xs:documentation>
                 </xs:annotation>
             </xs:element>
-            <xs:element maxOccurs="1" minOccurs="0" name="weather" type="siteWeatherData"/>
             <xs:element maxOccurs="1" minOccurs="0" name="existingGenerationCapability"
                 type="xs:boolean">
                 <xs:annotation>
@@ -2056,43 +2055,6 @@ When used for site surveys, should include what types of equipment are envisione
                 <xs:documentation>ID Ref of the associated equipment definition for this equipment instance.  For example, in case of a PVModule, this would be the ID of the PvModuleDefinition element that describes this particular PV module instance.</xs:documentation>
             </xs:annotation>
         </xs:attribute>
-    </xs:complexType>
-    <xs:complexType name="siteWeatherData">
-        <xs:annotation>
-            <xs:documentation>Describes what weather data to use in an analysis.  Provides a means to specify a location and type of weather file dataset to use in an analysis.</xs:documentation>
-        </xs:annotation>
-        <xs:sequence>
-            <xs:element name="stationCategory" type="xs:string" minOccurs="0">
-                <xs:annotation>
-                    <xs:documentation>Describes the set of weather stations, or geographic cells used to specify the site's weather.  Examples include: WBAN, WMO, NREL 40km Monthly Grid Cell, etc. </xs:documentation>
-                </xs:annotation>
-            </xs:element>
-            <xs:element minOccurs="0" name="stationId" type="xs:string">
-                <xs:annotation>
-                    <xs:documentation>The ID number used within the associated Station Category system.  If the Station Category is "WBAN," then this element would contain the WBAN number for the desired station.  For example, San Francisco, CA is WBAN "23234."  And Cairo, Egypt is WMO "623660."</xs:documentation>
-                </xs:annotation>
-            </xs:element>
-            <xs:element minOccurs="0" name="weatherDataset" type="xs:string">
-                <xs:annotation>
-                    <xs:documentation>Type of weather dataset, such as TMY, TMY2, IWEC, etc.</xs:documentation>
-                </xs:annotation>
-            </xs:element>
-            <xs:element minOccurs="0" name="highestMonthlyAverageHighTemperature" type="xs:integer">
-                <xs:annotation>
-                    <xs:documentation>Required for configuring inverter circuits. Of the monthly average high temperatures for the site, the highest one.</xs:documentation>
-                </xs:annotation>
-            </xs:element>
-            <xs:element minOccurs="0" name="recordLowTemperture" type="xs:integer">
-                <xs:annotation>
-                    <xs:documentation>Lowest historic temperature. Required for configuring PV inverter circuits. Used to find highest PV system string voltage when cold and sunny, and therefore longest possible string. </xs:documentation>
-                </xs:annotation>
-            </xs:element>
-            <xs:element minOccurs="0" name="designWindSpeed" type="xs:integer">
-                <xs:annotation>
-                    <xs:documentation>Required for PV system structural validations. For CA permitting guidebook, speed must be less than 110mph. This is based from ASCE 7-10, risk category II for CA.</xs:documentation>
-                </xs:annotation>
-            </xs:element>
-        </xs:sequence>
     </xs:complexType>
     <xs:complexType name="intervalDataDouble">
         <xs:annotation>

--- a/CommonSolar.xsd
+++ b/CommonSolar.xsd
@@ -1187,21 +1187,6 @@
             </xs:element>
         </xs:sequence>
     </xs:complexType>
-    <xs:complexType name="weatherData">
-        <xs:sequence>
-            <xs:element minOccurs="0" name="ExpectedHighTemperature" type="xs:decimal">
-                <xs:annotation>
-                    <xs:documentation>Expected highest temperature in degrees Celcius at the system's location.  Used to evaluate equipment derating.</xs:documentation>
-                </xs:annotation>
-            </xs:element>
-            <xs:element minOccurs="0" name="ExpectedLowTemperature" type="xs:decimal">
-                <xs:annotation>
-                    <xs:documentation>Expected lowest temperature in degrees Celcius at the system's location.  Used to evaluate maximum system output.</xs:documentation>
-                </xs:annotation>
-            </xs:element>
-            <xs:element minOccurs="0" name="siteWeatherData" type="siteWeatherData"/>
-        </xs:sequence>
-    </xs:complexType>
     <xs:complexType name="exclusionArea">
         <xs:annotation>
             <xs:documentation>For a module layout, this defines any area within a given scene that may contain multiple roofFaces and groundAreas that modules cannot be placed. The coordinates used in this element apply to the whole scene of roofFaces and groundAreas where moduleLayouts are placed (may contain more than one area).</xs:documentation>

--- a/Project.xsd
+++ b/Project.xsd
@@ -534,6 +534,7 @@ Included reference to Utility Service here instead of in Building since Project 
 					<xs:documentation>The site element describes the property on which the project is being considered or implemented.  It describes ownership and jurisdictional information, as well as physical attributes associated with the property and grounds. </xs:documentation>
 				</xs:annotation>
 			</xs:element>
+			<xs:element name="designParameters" type="projectDesignParameters" minOccurs="0"/>
 			<xs:element minOccurs="0" name="buildings">
 				<xs:complexType>
 					<xs:sequence>
@@ -681,5 +682,149 @@ The organization is consistent in many energy management systems and programable
 			</xs:element>
 		</xs:sequence>
 		<xs:attribute name="id" type="xs:ID"/>
+	</xs:complexType>
+	<xs:complexType name="projectDesignParameters">
+		<xs:annotation>
+			<xs:documentation>Describes various design parameters for analysis and modeling.</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="codes" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>A set of codes that this project must comply with.</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="code" type="code" maxOccurs="unbounded"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="temperature" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>A set of temperature datasets. Typically required for configuring inverter circuits.</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="temperatureDataset" type="temperatureDataset" maxOccurs="unbounded"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="structuralDesign" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>A set of parameters relevant to structural design.</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="asceEdition" minOccurs="0">
+							<xs:simpleType>
+								<xs:restriction base="xs:string">
+									<xs:enumeration value="ASCE_7_10"/>
+									<xs:enumeration value="ASCE_7_16"/>
+								</xs:restriction>
+							</xs:simpleType>
+						</xs:element>
+						<xs:element name="windExposureCategory" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Wind exposure categories as defined in ASCE 7.</xs:documentation>
+							</xs:annotation>
+							<xs:simpleType>
+								<xs:restriction base="xs:string">
+									<xs:enumeration value="B"/>
+									<xs:enumeration value="C"/>
+									<xs:enumeration value="D"/>
+								</xs:restriction>
+							</xs:simpleType>
+						</xs:element>
+						<xs:element name="topographicalCondition" minOccurs="0">
+							<xs:simpleType>
+								<xs:restriction base="xs:string">
+									<xs:enumeration value="STANDARD"/>
+									<xs:enumeration value="TOP_OF_HILL"/>
+									<xs:enumeration value="COASTAL"/>
+									<xs:enumeration value="MESA"/>
+								</xs:restriction>
+							</xs:simpleType>
+						</xs:element>
+						<xs:element name="designWindSpeed" type="velocity" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Required for PV system structural validations. For CA permitting guidebook, speed must be less than 110mph. This is based from ASCE 7-10, risk category II for CA.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="specialWindRegion" type="xs:boolean" minOccurs="0"/>
+						<xs:element name="groundSnowLoad" type="dimension" minOccurs="0"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="code">
+		<xs:annotation>
+			<xs:documentation>Defines code - a set of rules to comply with (e.g. California 2016 Fire Code)</xs:documentation>
+		</xs:annotation>
+		<xs:attribute name="type" use="required">
+			<xs:simpleType>
+				<xs:restriction base="xs:string">
+					<xs:enumeration value="FIRE"/>
+					<xs:enumeration value="ELECTRIC"/>
+				</xs:restriction>
+			</xs:simpleType>
+		</xs:attribute>
+		<xs:attribute name="codeBody" use="required">
+			<xs:simpleType>
+				<xs:restriction base="xs:string">
+					<xs:enumeration value="NATIONAL_FIRE_PROTECTION_ASSOCIATION"/>
+					<xs:enumeration value="CALIFORNIA"/>
+				</xs:restriction>
+			</xs:simpleType>
+		</xs:attribute>
+		<xs:attribute name="edition" type="xs:string" use="required"/>
+	</xs:complexType>
+	<xs:complexType name="temperatureDataset">
+		<xs:annotation>
+			<xs:documentation>A collection of temperature data points with metadata describing them.</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="temperatureDataPoint" type="temperatureDataPoint" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="type" use="required">
+			<xs:simpleType>
+				<xs:restriction base="xs:string">
+					<xs:enumeration value="HIGH"/>
+					<xs:enumeration value="LOW"/>
+				</xs:restriction>
+			</xs:simpleType>
+		</xs:attribute>
+		<xs:attribute name="source" use="required">
+			<xs:simpleType>
+				<xs:restriction base="xs:string">
+					<xs:enumeration value="ASHRAE"/>
+					<xs:enumeration value="HISTORIC"/>
+				</xs:restriction>
+			</xs:simpleType>
+		</xs:attribute>
+		<xs:attribute name="dateRecorded" type="xs:date" use="required"/>
+		<xs:attribute name="description" type="xs:string"/>
+	</xs:complexType>
+	<xs:complexType name="temperatureDataPoint">
+		<xs:simpleContent>
+			<xs:extension base="xs:decimal">
+				<xs:attribute name="type" use="required">
+					<xs:simpleType>
+						<xs:restriction base="xs:string">
+							<xs:enumeration value="RECORD_HIGH"/>
+							<xs:enumeration value="RECORD_LOW"/>
+							<xs:enumeration value="HIGHEST_MONTHLY_AVERAGE"/>
+							<xs:enumeration value="LOWEST_MONTHLY_AVERAGE"/>
+							<xs:enumeration value="MAXIMUM_MEAN_EXTREME_DRY_BULB"/>
+							<xs:enumeration value="MINIMUM_MEAN_EXTREME_DRY_BULB"/>
+							<xs:enumeration value="HIGHEST_MONTH_TWO_PERCENT_DRY_BULB"/>
+							<xs:enumeration value="HIGH_IN_CONDUIT_HALF_INCH_ABOVE_ROOF"/>
+							<xs:enumeration value="HIGH_IN_CONDUIT_THREE_AND_HALF_INCHES_ABOVE_ROOF"/>
+							<xs:enumeration value="HIGH_IN_CONDUIT_ONE_FOOT_ABOVE_ROOF"/>
+							<xs:enumeration value="HIGH_IN_CONDUIT_THREE_FEET_ABOVE_ROOF"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:attribute>
+			</xs:extension>
+		</xs:simpleContent>
 	</xs:complexType>
 </xs:schema>


### PR DESCRIPTION
Removed `//site/weatherData` in favor of a new `//project/designParameters` element.

The new element holds info about codes that apply, temperature datasets and structural design parameters. Example:
```xml
<iep:designParameters>
  <iep:codes>
    <iep:code type="FIRE" codeBody="CALIFORNIA" edition="2016"/>
    <iep:code type="ELECTRIC" codeBody="NATIONAL_FIRE_PROTECTION_ASSOCIATION" edition="2016"/>
  </iep:codes>
  <iep:temperature>
    <iep:temperatureDataset type="HIGH" source="ASHRAE" dateRecorded="2017-07-30" description="Optional comment or description of the dataset">
      <iep:temperatureDataPoint type="HIGHEST_MONTH_TWO_PERCENT_DRY_BULB">32</iep:temperatureDataPoint>
      <iep:temperatureDataPoint type="MAXIMUM_MEAN_EXTREME_DRY_BULB">38</iep:temperatureDataPoint>
    </iep:temperatureDataset>
    <iep:temperatureDataset type="HIGH" source="HISTORIC" dateRecorded="2015-01-22">
      <iep:temperatureDataPoint type="HIGHEST_MONTHLY_AVERAGE">29</iep:temperatureDataPoint>
    </iep:temperatureDataset>
    <iep:temperatureDataset type="LOW" source="HISTORIC" dateRecorded="2015-01-22">
      <iep:temperatureDataPoint type="RECORD_LOW">-8</iep:temperatureDataPoint>
    </iep:temperatureDataset>
  </iep:temperature>
  <iep:structuralDesign>
    <iep:asceEdition>ASCE_7_10</iep:asceEdition>
    <iep:windExposureCategory>B</iep:windExposureCategory>
    <iep:topographicalCondition>STANDARD</iep:topographicalCondition>
    <iep:designWindSpeed unit="MILES_PER_HOUR">110</iep:designWindSpeed>
    <iep:specialWindRegion>false</iep:specialWindRegion>
    <iep:groundSnowLoad>0</iep:groundSnowLoad>
  </iep:structuralDesign>
</iep:designParameters>
```
Note:
1. Enumerations are used extensively, but I'm not sure if I have specified all the required values.
1. `weatherData` type was removed from `CommonSolar.xsd`, because it was not used anywhere.